### PR TITLE
Suggested docker.txt changes

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -2732,7 +2732,8 @@ docker_info() {
 		log_cmd $OF "systemctl status docker.service"
 		log_cmd $OF 'docker info'
 		log_cmd $OF 'docker images'
-		log_cmd $OF 'docker ps'
+		log_cmd $OF 'docker ps --latest'
+		log_cmd $OF 'docker ps --all'
 		FILES='/etc/sysconfig/docker'
 		conf_files $OF $FILES
 		if rpm_verify $OF ruby2.1-rubygem-sle2docker
@@ -2740,6 +2741,17 @@ docker_info() {
 			log_cmd $OF 'sle2docker version'
 			log_cmd $OF 'sle2docker list'
 		fi
+		for i in $(docker ps | grep -v "COMMAND" | cut -c 1-12);
+		do
+			log_cmd $OF "docker top $i"
+		done
+		for i in $(docker ps | grep -v "COMMAND" | cut -c 1-12);
+		do
+			log_cmd $OF "docker logs $i"
+			log_cmd $OF "docker inspect $i"
+		done
+		log_cmd $OF 'ls -lah /var/lib/docker/containers'
+		log_cmd $OF 'ls -lahR /sys/fs/cgroup/*/system.slice/docker*'
 		log_cmd $OF 'journalctl -u docker'
 	fi
 	echolog Done

--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -2733,6 +2733,7 @@ docker_info() {
 		log_cmd $OF 'docker info'
 		log_cmd $OF 'docker images'
 		log_cmd $OF 'docker ps --all'
+		log_cmd $OF 'zypper --non-interactive --no-gpg-checks repos'
 		FILES='/etc/sysconfig/docker'
 		conf_files $OF $FILES
 		if rpm_verify $OF ruby2.1-rubygem-sle2docker
@@ -2740,7 +2741,7 @@ docker_info() {
 			log_cmd $OF 'sle2docker version'
 			log_cmd $OF 'sle2docker list'
 		fi
-		for i in $(docker ps -a | grep -v "COMMAND" | cut -c 1-12);
+		for i in $(docker ps -a | grep -v "COMMAND" | awk '{print $1}');
 		do
 			log_cmd $OF "docker top $i"
 			log_cmd $OF "docker logs $i"

--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -2732,7 +2732,6 @@ docker_info() {
 		log_cmd $OF "systemctl status docker.service"
 		log_cmd $OF 'docker info'
 		log_cmd $OF 'docker images'
-		log_cmd $OF 'docker ps --latest'
 		log_cmd $OF 'docker ps --all'
 		FILES='/etc/sysconfig/docker'
 		conf_files $OF $FILES
@@ -2741,17 +2740,14 @@ docker_info() {
 			log_cmd $OF 'sle2docker version'
 			log_cmd $OF 'sle2docker list'
 		fi
-		for i in $(docker ps | grep -v "COMMAND" | cut -c 1-12);
+		for i in $(docker ps -a | grep -v "COMMAND" | cut -c 1-12);
 		do
 			log_cmd $OF "docker top $i"
-		done
-		for i in $(docker ps | grep -v "COMMAND" | cut -c 1-12);
-		do
 			log_cmd $OF "docker logs $i"
 			log_cmd $OF "docker inspect $i"
 		done
-		log_cmd $OF 'ls -lah /var/lib/docker/containers'
-		log_cmd $OF 'ls -lahR /sys/fs/cgroup/*/system.slice/docker*'
+		log_cmd $OF 'ls -al --time-style=long-iso /var/lib/docker/containers'
+		log_cmd $OF 'ls -alR --time-style=long-iso /sys/fs/cgroup/*/system.slice/docker*'
 		log_cmd $OF 'journalctl -u docker'
 	fi
 	echolog Done

--- a/spec/supportutils.changes
+++ b/spec/supportutils.changes
@@ -2,6 +2,7 @@
 Tue Jan 26 14:00:00 MDT 2016 - chamilton@suse.com
 
 - Adjusted docker ps to include --all in docker.txt
+- Added a zypper command to check for repos needed by docker in docker.txt
 - Added docker top to docker.txt
 - Added docker logs to docker.txt
 - Added docker inspect to docker.txt


### PR DESCRIPTION
I suggest breaking the previous "docker ps" command into "docker ps --latest" and "docker ps --all". --latest will show the most recently created containers. the --all command unlike the ps command by itself will show both running and stopped docker containers.

Next I add two for loops. One is for running through only active containers and the other is for running through all containers stopped and started. The docker top command will only work on running containers, so it requires the first for loop. The other sub-commands logs and inspect are valuable for all containers running or not.

I had to use " instead of ' for the log_cmd commands within the for loops or it did not interpret the $i for loop variable.

Lastly I suggest listing the contents of certain directories to provide additional information on containers as well as to verify the files aren't missing. The directories I suggest are /var/lib/docker/containers and /sys/fs/cgroup/*/system.slice/docker*. It's possible that /var/lib/docker may be useful all together, but often times it is a very large directory resulting in a much larger docker.txt file than I'm not sure would be desired. I find that generally I just need the containers subdirectory of the /var/lib/docker directory. The other directory is to get more direct information about how it is relating to the cgroups. I found that docker information was always in a system.slice folder of various subdirectories of /sys/fs/cgroup, and that's the reason for the wild-cards.