### PR TITLE
gather /root/.bash_history

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -62,6 +62,7 @@ OPTION_ETC=1
 OPTION_EVMS=1
 OPTION_HA=1
 OPTION_HAPROXY=1
+OPTION_HISTORY=1
 OPTION_IB=1
 OPTION_IMAN=1
 OPTION_ISCSI=1
@@ -4795,6 +4796,14 @@ haproxy_info() {
 	fi
 }
 
+root_shell_history_info() {
+	printlog "root User Shell History..."
+	OF=history.txt
+	addHeaderFile $OF
+	log_files $OF 0 /root/.bash_history
+	echolog Done
+}
+
 memory_info() {
 	printlog "Memory Details..."
 	test $OPTION_MEM -eq 0 && { echolog Excluded; return 1; }
@@ -6740,6 +6749,7 @@ if [ "$USE_SAVED_LOGS_ONLY" != "1" ]; then
 	cimom_info
 	open_files
 	environment_info
+	root_shell_history_info
 	etc_info
 	sysconfig_info
 	sysfs_info

--- a/man/supportconfig.conf.5
+++ b/man/supportconfig.conf.5
@@ -87,6 +87,9 @@ Heartbeat/high availabilty cluster information. \fBha.txt\fR (1)
 OPTION_HAPROXY
 Heartbeat/high availabilty proxy cluster information. \fBhaproxy.txt\fR (1)
 .TP
+OPTION_HISTORY
+root user shell history. \fBhistory.txt\fR (1)
+.TP
 OPTION_IB
 InfiniBand information. Only available with SLE11 or greater. \fBib.txt\fR (1)
 .TP


### PR DESCRIPTION
Understanding what actions the sysadmins took manually, and when, can be hugely valuable when doing root cause analysis.