### PR TITLE
Fix path to virt-manager log file

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -4310,12 +4310,12 @@ xen_info() {
 
 
 		if [ $ADD_OPTION_LOGS -gt 0 ]; then
-			test -d /root/.virt-manager && FILES="$(find -L /root/.virt-manager/ -type f)" || FILES=""
+			test -d /root/.cache/virt-manager && FILES="$(find -L /root/.cache/virt-manager/ -type f)" || FILES=""
 			test -d /var/log/xen && FILES="$FILES $(find -L /var/log/xen/ -type f | sort)"
 			test -d /var/log/libvirt && FILES="$FILES $(find -L /var/log/libvirt/ -name libvirtd.log* -type f | sort)"
 			test -d /var/log/libvirt/libxl && FILES="$FILES $(find -L /var/log/libvirt/libxl/ -type f | sort)"
 		else
-			test -d /root/.virt-manager && FILES=/root/.virt-manager/virt-manager.log || FILES=""
+			test -d /root/.cache/virt-manager && FILES=/root/.cache/virt-manager/virt-manager.log || FILES=""
 			test -d /var/log/xen && FILES="$FILES $(find -L /var/log/xen/ -type f | grep 'log$' | sort)"
 			test -d /var/log/libvirt && FILES="$FILES $(find -L /var/log/libvirt/ -name libvirtd.log -type f)"
 			test -d /var/log/libvirt/libxl && FILES="$FILES $(find -L /var/log/libvirt/libxl/ -type f | grep 'log$' | sort)"
@@ -4409,11 +4409,11 @@ kvm_info() {
 		fi
 
 		if [ $ADD_OPTION_LOGS -gt 0 ]; then
-			test -d /root/.virt-manager && FILES="$(find -L /root/.virt-manager/ -type f)" || FILES=""
+			test -d /root/.cache/virt-manager && FILES="$(find -L /root/.cache/virt-manager/ -type f)" || FILES=""
 			test -d /var/log/libvirt && FILES="$FILES $(find -L /var/log/libvirt/ -name libvirtd.log* -type f | sort)"
 			test -d /var/log/libvirt/qemu && FILES="$FILES $(find -L /var/log/libvirt/qemu/ -type f | sort)"
 		else
-			test -d /root/.virt-manager && FILES=/root/.virt-manager/virt-manager.log || FILES=""
+			test -d /root/.cache/virt-manager && FILES=/root/.cache/virt-manager/virt-manager.log || FILES=""
 			test -d /var/log/libvirt && FILES="$FILES $(find -L /var/log/libvirt/ -name libvirtd.log -type f)"
 			test -d /var/log/libvirt/qemu && FILES="$FILES $(find -L /var/log/libvirt/qemu/ -type f | grep 'log$' | sort)"
 		fi
@@ -4465,11 +4465,11 @@ lxc_info() {
 			conf_text_files $OF $FILES
 
 			if [ $ADD_OPTION_LOGS -gt 0 ]; then
-				test -d /root/.virt-manager && FILES="$(find -L /root/.virt-manager/ -type f)" || FILES=""
+				test -d /root/.cache/virt-manager && FILES="$(find -L /root/.cache/virt-manager/ -type f)" || FILES=""
 				test -d /var/log/libvirt && FILES="$FILES $(find -L /var/log/libvirt/ -name libvirtd.log* -type f | sort)"
 				test -d /var/log/libvirt/lxc && FILES="$FILES $(find -L /var/log/libvirt/lxc/ -type f | sort)"
 			else
-				test -d /root/.virt-manager && FILES=/root/.virt-manager/virt-manager.log || FILES=""
+				test -d /root/.cache/virt-manager && FILES=/root/.cache/virt-manager/virt-manager.log || FILES=""
 				test -d /var/log/libvirt && FILES="$FILES $(find -L /var/log/libvirt/ -name libvirtd.log -type f)"
 				test -d /var/log/libvirt/lxc && FILES="$FILES $(find -L /var/log/libvirt/lxc/ -type f | grep 'log$' | sort)"
 			fi


### PR DESCRIPTION
Starting with SLE12 GA, the virt-manager log file is placed in
/root/.cache/virt-manager/. Change supportconfig to look for the
log files in the new path.