### PR TITLE
Check docker rpm package name properly, bsc#1069457

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -1170,7 +1170,8 @@ docker_info() {
 	test $OPTION_DOCKER -eq 0 && { echolog Excluded; return 1; }
 	OF=docker.txt
 	addHeaderFile $OF
-	if rpm_verify $OF docker
+	[ -e /usr/bin/docker ] && DOCKER_PKG=`rpm -q --whatprovides /usr/bin/docker`
+	if rpm_verify $OF $DOCKER_PKG
 	then
 		log_cmd $OF 'docker version'
 		log_cmd $OF "systemctl status docker.service"


### PR DESCRIPTION
Docker package in OBS/Devel:CASP:Head:ControllerNode is called docker_1_12_6,
we need to check if this package was installed and provide containers
information by supportconfig.