### PR TITLE
Getting list of RPM DB Backups

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -500,6 +500,9 @@ rpm_info() {
 		rpm -qa --queryformat "%-35{NAME} %-35{DISTRIBUTION} %{VERSION}-%{RELEASE}\n" | sort -k 1,2 -t " " -i >> $LOGFILE 2>&1
 		log_write $RPMFILE
 		log_cmd $RPMFILE "rpm -qa --last"
+		# Jul 12, 2018 ; Added by Ahmad AL Zayed to get a list of RPM DB Backups 
+		RETURN=$(grep RPMDB_BACKUP_DIR /etc/sysconfig/backup | grep -v "^#" | cut -d= -f2 | tr -d "\"") 
+		[[ -d $RETURN ]] && { log_cmd $RPMFILE "ls -ltr $RETURN" ;} 
 	fi
 	echolog Done
 }


### PR DESCRIPTION
Sometimes I find it useful to get list or RPM DB backups. 
The changes will add below to rpm.txt file : 
#==[ Command ]======================================#
# /bin/ls -ltr /var/adm/backup/rpmdb
total 214960
-rw-r--r-- 1 root root 44055375 Jun 29 07:24 Packages-20180629.gz
-rw-r--r-- 1 root root 44048580 Jul  2 09:12 Packages-20180702.gz
-rw-r--r-- 1 root root 43999129 Jul  3 09:10 Packages-20180703.gz
-rw-r--r-- 1 root root 43996288 Jul  6 07:53 Packages-20180706.gz
-rw-r--r-- 1 root root       36 Jul  8 13:19 rpmdb_recent_md5
-rw-r--r-- 1 root root 44005699 Jul  8 13:19 Packages-20180708.gz