### PR TITLE
systemd: Sort properties lexicographically

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -1199,7 +1199,7 @@ systemd_info() {
 	log_cmd $OF 'systemd-delta --no-pager'
 	FILES=''
 	[[ -d /etc/systemd ]] && FILES=$(find -L /etc/systemd -maxdepth 1 -type f)
-	log_cmd $OF 'systemctl --no-pager show'
+	log_cmd $OF 'systemctl --no-pager show | sort'
 	conf_files $OF $FILES
 	log_cmd $OF 'systemctl --no-pager --all list-units'
 	log_cmd $OF 'systemctl --no-pager --all list-sockets'
@@ -1211,7 +1211,7 @@ systemd_info() {
 		then
 			break
 		else
-			log_cmd $OF "systemctl show '$i'"
+			log_cmd $OF "systemctl show '$i' | sort"
 		fi
 	done
 	log_cmd $OF 'ls -alR /etc/systemd/'


### PR DESCRIPTION
Properties are printed in random order (the internal structures do not
specify no particular order). It is more convenient for reading and
comparing unit properties when the output is sorted.

Some ballbark measurements don't show a significant effect of the
sorting:

echo 3 >/proc/sys/vm/drop_caches ; time supportconfig -m -o DAEMONS

before:
real    0m51.710s
user    0m15.970s
sys     0m4.532s

real    0m51.020s
user    0m15.741s
sys     0m4.676s

after:
real    0m50.575s
user    0m16.232s
sys     0m4.758s

real    0m50.599s
user    0m16.394s
sys     0m4.796s

echo 3 >/proc/sys/vm/drop_caches ; time supportconfig.2 -m -o DAEMONS

after-systemd only:
real    0m20.992s
user    0m6.270s
sys     0m2.811s

real    0m21.030s
user    0m6.230s
sys     0m2.753s

before-systemd only:
real    0m20.856s
user    0m5.942s
sys     0m2.495s

real    0m20.569s
user    0m5.948s
sys     0m2.548s

real    0m21.134s
user    0m5.872s
sys     0m2.497s

(supportconfig.2 was patched to exclude all but systemd module, i.e.
also the minimal modules)