### PR TITLE
[powerpc] Add support to collect DLPAR and LPM related logs

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -1637,6 +1637,21 @@ hardware_info() {
 		"pSeries")
 			log_entry $OF command "cp /proc/ppc64/eeh /proc/ppc64/lparcfg /proc/ppc64/systemcfg /var/log/platform /dev/nvram $PPC_DIR"
 			cp /proc/ppc64/eeh /proc/ppc64/lparcfg /proc/ppc64/systemcfg /var/log/platform /dev/nvram $PPC_DIR 2>/dev/null
+
+			if rpm -q rsct.core.utils &>/dev/null; then
+				CTSNAP_DIR="${PPC_DIR}/ctsnap"
+				mkdir -p $CTSNAP_DIR
+				log_cmd $OF "ctsnap -xrunrpttr -d $CTSNAP_DIR"
+			fi
+
+			if [[ -f /var/log/drmgr ]]; then
+				log_entry $OF command "cp /var/log/drmgr $PPC_DIR"
+				cp /var/log/drmgr $PPC_DIR 2>/dev/null
+			fi
+			if [[ -f /var/log/drmgr.0 ]]; then
+				log_entry $OF command "cp /var/log/drmgr.0 $PPC_DIR"
+				cp /var/log/drmgr.0 $PPC_DIR 2>/dev/null
+			fi
 			;;
 		"PowerNV")
 			log_entry $OF command "cp /proc/ppc64/eeh /proc/ppc64/systemcfg /proc/ppc64/topology_updates /sys/firmware/opal/msglog /var/log/opal-elog /dev/nvram $PPC_DIR"


### PR DESCRIPTION
This patch allow supportutils to collect
Dynamic Resource Manager (drmgr) log files i.e.
/var/log/drmgr and /var/log/drmgr.0.
In addition, it also adds ctsanp command to collect the information
about Reliable Scalable Cluster Technology (RSCT) components.

Signed-off-by: Sourabh Jain <sourabhjain@linux.ibm.com>