### PR TITLE
Btrfs handling

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -1988,11 +1988,17 @@ btrfs_info() {
 		[[ -x /usr/bin/findmnt ]] && log_cmd $OF "findmnt" || log_cmd $OF "mount"
 		log_cmd $OF "df -h"
 		log_cmd $OF "modinfo btrfs"
-		for DISK in $(mount | grep -i btrfs | awk '{ print $3 }')
-		do
-			log_cmd $OF "btrfs filesystem df $DISK"
-			log_cmd $OF "btrfs scrub status $DISK"
-		done
+                for DEVICE in $(btrfs filesystem show | awk 'NF{ print $NF }' | grep ^/)
+                #TODO For multi-device btrfs filesysems only use one device
+                do
+                        for FILESYS in $(findmnt -S $DEVICE --types btrfs --list --output target --first-only --noheadings)
+                        do
+                                log_cmd $OF "btrfs filesystem df $FILESYS"
+                                log_cmd $OF "btrfs scrub status $FILESYS"
+                                log_cmd $OF "btrfs subvolume get-default $SUB_VOL"
+                                log_cmd $OF "btrfs subvolume list $SUB_VOL"
+                        done
+                done
 
 		if rpm_verify $OF snapper; then
 			log_cmd $OF "snapper list-configs"
@@ -2000,9 +2006,6 @@ btrfs_info() {
 			for PAIR in $CONFIGS
 			do
 				CONFIG=$(echo $PAIR | cut -d\| -f1)
-				SUB_VOL=$(echo $PAIR | cut -d\| -f2)
-				log_cmd $OF "btrfs subvolume get-default $SUB_VOL"
-				log_cmd $OF "btrfs subvolume list $SUB_VOL"
 				log_cmd $OF "snapper -c $CONFIG list"
 			done
 			conf_files $OF /etc/sysconfig/snapper /etc/snapper/configs/* /etc/snapper/filters/*

--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -1994,9 +1994,6 @@ btrfs_info() {
 			log_cmd $OF "btrfs scrub status $DISK"
 		done
 
-		FILES="/var/log/messages"
-		test $ADD_OPTION_LOGS -gt 0 && grep_log_files btrfs $OF 0 $FILES || grep_log_files btrfs $OF $VAR_OPTION_LINE_COUNT $FILES
-
 		if rpm_verify $OF snapper; then
 			log_cmd $OF "snapper list-configs"
 			CONFIGS=$(snapper --table-style 0 list-configs | sed -e 's/[[:space:]]*//g;1,2d')
@@ -2010,6 +2007,9 @@ btrfs_info() {
 			done
 			conf_files $OF /etc/sysconfig/snapper /etc/snapper/configs/* /etc/snapper/filters/*
 		fi
+                FILES="/var/log/messages"
+                test $ADD_OPTION_LOGS -gt 0 && grep_log_files btrfs $OF 0 $FILES || grep_log_files btrfs $OF $VAR_OPTION_LINE_COUNT $FILES
+
 		FILES="/var/log/snapper.log"
 		test $ADD_OPTION_LOGS -gt 0 && log_files $OF 0 $FILES || log_files $OF $VAR_OPTION_LINE_COUNT $FILES
 		echolog Done

--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -2005,7 +2005,7 @@ btrfs_info() {
 				CONFIG=$(echo $PAIR | cut -d\| -f1)
 				SUB_VOL=$(echo $PAIR | cut -d\| -f2)
 				log_cmd $OF "btrfs subvolume get-default $SUB_VOL"
-				log_cmd $OF "btrfs subvolume list $SUB_VOL | grep -v '.snapshots'"
+				log_cmd $OF "btrfs subvolume list $SUB_VOL"
 				log_cmd $OF "snapper -c $CONFIG list"
 			done
 			conf_files $OF /etc/sysconfig/snapper /etc/snapper/configs/* /etc/snapper/filters/*


### PR DESCRIPTION
Improved handling of btrfs commands in fs-btrfs.txt
This will reduce the duplicate information caused by checking all mounted btrfs subvolumes even if they are in the same filesystem.
No longer relies on snapper for subolume list, default subvol, and includes subvolumes under the .snapshots directory