### PR TITLE
Switch to usage for more detailed info

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -1994,7 +1994,7 @@ btrfs_info() {
                 do
                         for FILESYS in $(findmnt -S $DEVICE --types btrfs --list --output target --first-only --noheadings)
                         do
-                                log_cmd $OF "btrfs filesystem df $FILESYS"
+                                log_cmd $OF "btrfs filesystem usage $FILESYS"
                                 log_cmd $OF "btrfs scrub status $FILESYS"
                                 log_cmd $OF "btrfs subvolume get-default $SUB_VOL"
                                 log_cmd $OF "btrfs subvolume list $SUB_VOL"


### PR DESCRIPTION
btrfs filesystem usage gives more detailed information than "df" and is meant to replace it.