### PR TITLE
supportconfig: open-files: Throw away lsof errors

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -3040,7 +3040,7 @@ open_files() {
 	addHeaderFile $OF
 	if rpm_verify $OF lsof
 	then
-		log_cmd $OF "lsof -b +M -n -l"
+		log_cmd $OF "lsof -b +M -n -l 2>/dev/null"
 		echolog Done
 	else
 		echolog Skipped


### PR DESCRIPTION
From now on, all errors reported by lsof, like bellow, will be
discarted:
lsof: avoiding readlink(/proc): -b was specified.
lsof: avoiding stat(/proc): -b was specified.

In crash function lsof also discards errors, so let's do the same to
open-files function.

Signed-off-by: Marcos Paulo de Souza <mpdesouza@suse.de>