### PR TITLE
etc_info: Add support for .cfg files in /etc dir

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -3289,7 +3289,7 @@ etc_info() {
 	test $OPTION_ETC -eq 0 && { echolog Excluded; return 1; }
 	OF=etc.txt
 	addHeaderFile $OF
-	conf_files $OF $(find -L /etc/ -type f | grep conf$)
+	conf_files $OF $(find -L /etc/ -type f | egrep "conf$|cfg$")
 	[ -d /etc/logrotate.d ] && conf_files $OF /etc/logrotate.d/*
 	conf_files $OF /etc/rc.dialout /etc/ppp/options /etc/ppp/ioptions /etc/ppp/peers/pppoe
 	echolog Done


### PR DESCRIPTION
cloud-init config files ehave .cfg suffix, so this change makes
supportconfig to also log cloud-init related configuration.

Signed-off-by: Marcos Paulo de Souza <mpdesouza@suse.de>