### PR TITLE
supportconfig: Silence warning in rpm backup db collection path

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -500,7 +500,7 @@ rpm_info() {
 		log_write $RPMFILE
 		log_cmd $RPMFILE "rpm -qa --last"
 		# Jul 12, 2018 ; Added by Ahmad AL Zayed to get a list of RPM DB Backups 
-		RETURN=$(grep RPMDB_BACKUP_DIR /etc/sysconfig/backup | grep -v "^#" | cut -d= -f2 | tr -d "\"") 
+		RETURN=$(grep RPMDB_BACKUP_DIR /etc/sysconfig/backup 2>/dev/null | grep -v "^#" | cut -d= -f2 | tr -d "\"")
 		[[ -d $RETURN ]] && { log_cmd $RPMFILE "ls -ltr $RETURN" ;} 
 	fi
 	echolog Done


### PR DESCRIPTION
Sample log:
----------
RPM Database...   grep: /etc/sysconfig/backup: No such file or directory

Signed-off-by: Vasant Hegde <hegdevasant@linux.vnet.ibm.com>