### PR TITLE
Set files in tarball to 660 instead of 600

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -4419,8 +4419,8 @@ fi
 
 cd $LOG
 cd ..
-wait_trace_on -t "tar ${COMPRESS_OPT} ${TARBALL} ${BASE}/*"
-tar ${COMPRESS_OPT} ${TARBALL} ${BASE}/*
+wait_trace_on -t "tar ${COMPRESS_OPT} ${TARBALL} --mode='ug+rw' ${BASE}/*"
+tar ${COMPRESS_OPT} ${TARBALL} --mode='ug+rw' ${BASE}/*
 LOGSIZE=$(ls -lh ${TARBALL} | awk '{print $5}')
 wait_trace_off -t
 wait_trace_on -t "md5sum $TARBALL"


### PR DESCRIPTION
Currently files are compressed and extracted with permissions of 600 which causes extra steps when needing to collaborate with others. This sets tar to archive them as 660.