### PR TITLE
supportconfig: Log udev rules in etc.txt file

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -3131,7 +3131,7 @@ etc_info() {
 	test $OPTION_ETC -eq 0 && { echolog Excluded; return 1; }
 	OF=etc.txt
 	addHeaderFile $OF
-	conf_files $OF $(find -L /etc/ -type f | egrep "conf$|cfg$")
+	conf_files $OF $(find -L /etc/ -type f | egrep "conf$|cfg$|rules$")
 	[ -d /etc/logrotate.d ] && conf_files $OF /etc/logrotate.d/*
 	conf_files $OF /etc/rc.dialout /etc/ppp/options /etc/ppp/ioptions /etc/ppp/peers/pppoe
 	echolog Done


### PR DESCRIPTION
This is useful to check rules like 70-persistent-net.rules in affected
systems.

Signed-off-by: Marcos Paulo de Souza <mpdesouza@suse.com>