### PR TITLE
For YEARS now, pet peeve of mine when looking at multiple supportconf…

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -240,7 +240,7 @@ basic_healthcheck() {
 	log_cmd $OF 'grep -H . /sys/devices/system/cpu/vulnerabilities/*'
 	log_cmd $OF 'vmstat 1 4'
 	test -x /usr/bin/mpstat && log_cmd $OF 'mpstat -P ALL 1 3'
-	log_cmd $OF 'free -k'
+	log_cmd $OF 'free -h'
 	timed_log_cmd $OF 'df -h' || IO_DELAYS=1
 	(( $IO_DELAYS )) || log_cmd $OF 'df -i'
 	conf_files $OF '/proc/sys/kernel/tainted'
@@ -2863,7 +2863,7 @@ memory_info() {
 	OF=memory.txt
 	addHeaderFile $OF
 	log_cmd $OF "vmstat 1 4"
-	log_cmd $OF "free -k"
+	log_cmd $OF "free -h"
 	conf_files $OF /proc/meminfo /proc/vmstat
 	log_cmd $OF 'sysctl -a 2>/dev/null | grep ^vm'
 	[ -d /sys/kernel/mm/transparent_hugepage/ ] && FILES=$(find /sys/kernel/mm/transparent_hugepage/ -type f) || FILES=''


### PR DESCRIPTION
…igs and

having to do math in my head converting kilobytes to megabytes to
gigabytes.

pazzo:~/SR101244197511/nts_zlnx166_java_190711_1718_appcore # free -h
             total       used       free     shared    buffers     cached
Mem:          1.9G       1.1G       812M       8.3M        11M        89M
-/+ buffers/cache:       1.1G       913M
Swap:           0B         0B         0B

free -h
              total        used        free      shared  buff/cache   available
Mem:            31G         11G         12G        717M        6.6G         18G
Swap:          2.0G          0B        2.0G

So much easier to read.