### PR TITLE
Fix typo in supportconfig.rc

### DIFF
--- a/bin/supportconfig.rc
+++ b/bin/supportconfig.rc
@@ -431,7 +431,7 @@ log_cmd() {
 		wait_trace_off
 	else
 		echo "# $CMDLINE_ORIG" >> $LOGFILE
-		echo "ERROR: Command not found or not executible" >> $LOGFILE
+		echo "ERROR: Command not found or not executable" >> $LOGFILE
 		EXIT_STATUS=1
 	fi
 	echo >> $LOGFILE
@@ -515,7 +515,7 @@ TEOF
 		wait_trace_off
 	else
 		echo "# $CMDLINE_ORIG" >> $LOGFILE
-		echo "ERROR: Command not found or not executible" >> $LOGFILE
+		echo "ERROR: Command not found or not executable" >> $LOGFILE
 		EXIT_STATUS=1
 	fi
 	echo >> $LOGFILE
@@ -768,7 +768,7 @@ exec_plugins() {
 					fi
 				fi
 			else
-				log_write $PLUGIN_LOG_FILE "ERROR: Missing or non-executible plugin"
+				log_write $PLUGIN_LOG_FILE "ERROR: Missing or non-executable plugin"
 				((PLUGIN_ERROR++))
 			fi
 			log_write $PLUGIN_LOG_FILE


### PR DESCRIPTION
Hey :wave:, I just thought that it is meant to be called `executable`.