### PR TITLE
memory_info: Show VMware memory balloon infomation

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -2879,6 +2879,9 @@ memory_info() {
 		log_cmd $OF 'numactl --hardware'
 		log_cmd $OF 'numastat'
 	fi
+	if [ -e /sys/kernel/debug/vmmemctl ]; then
+		conf_files $OF /sys/kernel/debug/vmmemctl
+	fi
 	if [ -x /usr/bin/pmap ]; then
 		for I in $(ps axo pid)
 		do


### PR DESCRIPTION
Customers observed a lot of OOM problems which are caused by
VMware memory balloon dirver which can reserve a lot of physical
memory in its internal memory pool. However, these reserved physical
memory are not tracked in /proc/meminfo. So /sys/kernel/debug/vmmemctl
would be used as a complement of /proc/meminfo for debugging this kind
of memory issues.

Signed-off-by: Firo Yang <firogm@gmail.com>