### PR TITLE
supportconfig: fs-btrfs: Add "btrfs device stats" output

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -1897,8 +1897,8 @@ btrfs_info() {
                                 log_cmd $OF "btrfs balance status -v $FILESYS"
                                 log_cmd $OF "btrfs subvolume get-default $FILESYS"
                                 log_cmd $OF "btrfs subvolume list $FILESYS"
-				# Added By Ahmad Al Zayed ; Mar 12, 2019 ; to get a list of btrfs quota
 				log_cmd $OF "btrfs qgroup show -r $FILESYS" 
+				log_cmd $OF "btrfs device stats $FILESYS"
                         done
                 done
 


### PR DESCRIPTION
This would help us to track if the underlying storage is having
problems.

Also, remove a comment about when a line of code was introduced. This
can be checked using "git log".

Signed-off-by: Marcos Paulo de Souza <mpdesouza@suse.com>