### PR TITLE
Let us collect SAP HANA status

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -2525,6 +2525,9 @@ ha_info() {
 			# More corosync information ; Dec 06, 2018 ; Added by Ahmad Al Zayed
 			log_cmd $OF 'crm corosync status' 
 			log_cmd $OF 'crm configure show'
+			# Collect SAP HANA Status ; Oct 29, 2020 ; Added by Ahmad Alzayed 
+			[[ -x /usr/sbin/SAPHanaSR-monitor ]] && { log_cmd $OF 'SAPHanaSR-monitor' ;}
+                        [[ -x /usr/sbin/SAPHanaSR-showAttr ]] && { log_cmd $OF 'SAPHanaSR-showAttr' ;} 
 			conf_files $OF $CONF_FILES
 			if [[ -s /etc/sysconfig/sbd ]]; then
 				. /etc/sysconfig/sbd
@@ -2605,6 +2608,9 @@ ha_info() {
 			# More corosync information ; Dec 6, 2018 ; Added by Ahmad Al Zayed
 			log_cmd $OF 'crm corosync status' 
 			log_cmd $OF 'crm configure show'
+			# Collect SAP HANA Status ; Oct 29, 2020 ; Added by Ahmad Alzayed 
+			[[ -x /usr/sbin/SAPHanaSR-monitor ]] && { log_cmd $OF 'SAPHanaSR-monitor' ;}
+                        [[ -x /usr/sbin/SAPHanaSR-showAttr ]] && { log_cmd $OF 'SAPHanaSR-showAttr' ;}
 			conf_files $OF $CONF_FILES
 			if [[ -s /etc/sysconfig/sbd ]]; then
 				. /etc/sysconfig/sbd


### PR DESCRIPTION
Added: 
			[[ -x /usr/sbin/SAPHanaSR-monitor ]] && { log_cmd $OF 'SAPHanaSR-monitor' ;}
                        [[ -x /usr/sbin/SAPHanaSR-showAttr ]] && { log_cmd $OF 'SAPHanaSR-showAttr' ;}

to both 12 and 15 sections. But seems we can reduce the amount of code to make it more nicer. If you agree I can work on it next week.