### PR TITLE
Fix spelling typos in man pages

### DIFF
--- a/man/supportconfig.8
+++ b/man/supportconfig.8
@@ -149,7 +149,7 @@ Use -F to see a list of valid keywords. Do not use spaces and keywords are case-
 .RE
 .TP
 \fB\-k\fR 
-Disable automatic kernel module loading. Some of the system commands (ie hwinfo), automatically load kernel modules for probing purposes. On rare occassions these additional kernel modules have caused unexpected behavior. This option will not run any system command that is known to load kernel modules. Do not use this option, unless directed by NTS.
+Disable automatic kernel module loading. Some of the system commands (ie hwinfo), automatically load kernel modules for probing purposes. On rare occasions these additional kernel modules have caused unexpected behavior. This option will not run any system command that is known to load kernel modules. Do not use this option, unless directed by NTS.
 .TP
 \fB\-l\fR 
 Includes all log file lines. Gathers additional rotated logs. Includes commented lines in all configuration files. 

--- a/man/supportconfig.conf.5
+++ b/man/supportconfig.conf.5
@@ -73,16 +73,16 @@ OPTION_EVMS
 Enterprise Volume Management System related information. \fBevms.txt\fR (1)
 .TP
 OPTION_HA
-Heartbeat/high availabilty cluster information. \fBha.txt\fR (1)
+Heartbeat/high availability cluster information. \fBha.txt\fR (1)
 .TP
 OPTION_HAPROXY
-Heartbeat/high availabilty proxy cluster information. \fBhaproxy.txt\fR (1)
+Heartbeat/high availability proxy cluster information. \fBhaproxy.txt\fR (1)
 .TP
 OPTION_HISTORY
 root user shell history. \fBhistory.txt\fR (0)
 .TP
 OPTION_IB
-InfiniBand information. Only available with SLE11 or greater. \fBib.txt\fR (1)
+InfiniBand information. Only available with SLES11 or greater. \fBib.txt\fR (1)
 .TP
 OPTION_ISCSI
 iSCSI target and initiator information. \fBfs-iscsi.txt\fR (1)
@@ -195,7 +195,7 @@ XEN virtualization related information. \fBxen.txt\fR (1)
 Each additional regular option is described with the TOKEN used, a description, the \fBstartup option\fR used to set it, the \fBfilename\fR if any and the default value in (parenthesis). If no startup option is listed, then you must set this option in the supportconfig.conf file.
 .TP
 ADD_OPTION_FSLIST
-A full file list using find from the root of the filesytem. \fB\-L\fR, \fBfs-files.txt\fR (0)
+A full file list using find from the root of the filesystem. \fB\-L\fR, \fBfs-files.txt\fR (0)
 .TP
 ADD_OPTION_LOGS
 Includes the entire log file, including comments, instead of just VAR_OPTION_LINE_COUNT lines of it. Additional rotated logs are included if available. \fB\-l\fR (0)


### PR DESCRIPTION
This patch fixes some spelling typo found in
supportconfig.8 and supportconfig.conf.5

Signed-off-by: Masanari Iida <standby24x7@gmail.com>