### PR TITLE
btrfs_info: add -pce argument to qgroup show

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -1901,7 +1901,7 @@ btrfs_info() {
                                 log_cmd $OF "btrfs balance status -v $FILESYS"
                                 log_cmd $OF "btrfs subvolume get-default $FILESYS"
                                 log_cmd $OF "btrfs subvolume list $FILESYS"
-				log_cmd $OF "btrfs qgroup show -r $FILESYS" 
+				log_cmd $OF "btrfs qgroup show -prce $FILESYS"
 				log_cmd $OF "btrfs device stats $FILESYS"
                         done
                 done


### PR DESCRIPTION
Instead of showing only limit of referenced size of qgroup, add parent
group id, child group id and limit of exclusive size of qgroup.

Signed-off-by: Marcos Paulo de Souza <mpdesouza@suse.com>