### PR TITLE
docker: add /etc/docker/daemon.json contents

### DIFF
--- a/bin/supportconfig
+++ b/bin/supportconfig
@@ -1118,7 +1118,7 @@ docker_info() {
 		log_cmd $OF 'docker images'
 		log_cmd $OF 'docker ps --all'
 		log_cmd $OF 'docker network ls'
-		FILES='/etc/sysconfig/docker'
+		FILES=('/etc/sysconfig/docker' '/etc/docker/daemon.json')
 		conf_files $OF $FILES
 		if rpm_verify $OF ruby2.1-rubygem-sle2docker
 		then


### PR DESCRIPTION
Users can now configure docker using /etc/docker/daemon.json, so having
the contents of this file is important when debugging issues.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>